### PR TITLE
Fix typo: Change "Automtically" to "Automatically"

### DIFF
--- a/_articles/automatically-unsubscribing-emails-that-have-bounced.md
+++ b/_articles/automatically-unsubscribing-emails-that-have-bounced.md
@@ -1,6 +1,6 @@
 ---
 layout: articles
-title:  Automtically unsubscribing emails that have bounced
+title:  Automatically unsubscribing emails that have bounced
 categories: deliverability
 ---
 

--- a/_site/articles/automatically-unsubscribing-emails-that-have-bounced.html
+++ b/_site/articles/automatically-unsubscribing-emails-that-have-bounced.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <title>Automtically unsubscribing emails that have bounced</title>
+  <title>Automatically unsubscribing emails that have bounced</title>
 
   <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-M8KWK" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-M8KWK');</script>

--- a/_site/articles/dedicated-ips.html
+++ b/_site/articles/dedicated-ips.html
@@ -127,7 +127,7 @@
           
             
               <li>
-                <a class="article-link" href="/articles/automatically-unsubscribing-emails-that-have-bounced.html">Automtically unsubscribing emails that have bounced</a>
+                <a class="article-link" href="/articles/automatically-unsubscribing-emails-that-have-bounced.html">Automatically unsubscribing emails that have bounced</a>
               </li>
             
           

--- a/_site/articles/how-to-setup-my-domain-signing-and-remove-via-getveromail-com-from-your-emails.html
+++ b/_site/articles/how-to-setup-my-domain-signing-and-remove-via-getveromail-com-from-your-emails.html
@@ -162,7 +162,7 @@ Verify DNS Records button.</p>
           
             
               <li>
-                <a class="article-link" href="/articles/automatically-unsubscribing-emails-that-have-bounced.html">Automtically unsubscribing emails that have bounced</a>
+                <a class="article-link" href="/articles/automatically-unsubscribing-emails-that-have-bounced.html">Automatically unsubscribing emails that have bounced</a>
               </li>
             
           

--- a/_site/articles/using-other-email-service-providers-with-Vero.html
+++ b/_site/articles/using-other-email-service-providers-with-Vero.html
@@ -129,7 +129,7 @@
           
             
               <li>
-                <a class="article-link" href="/articles/automatically-unsubscribing-emails-that-have-bounced.html">Automtically unsubscribing emails that have bounced</a>
+                <a class="article-link" href="/articles/automatically-unsubscribing-emails-that-have-bounced.html">Automatically unsubscribing emails that have bounced</a>
               </li>
             
           

--- a/_site/articles/what-are-external-attributes.html
+++ b/_site/articles/what-are-external-attributes.html
@@ -148,6 +148,10 @@
 
 <p>This is a basic case, but additional ones like the ones mentioned above, or even full html creative sections could be pulled in as you’d like.</p>
 
+<h2 id="authentication">Authentication</h2>
+
+<p>At this time External Attributes only supports basic HTTP Authentication. You can include basic HTTP Authentication details using the format <code>http://username:password@yoururl.com/data-feed.json</code>. This is supported by both the <code>fetch_html</code> and JSON fetch methods.</p>
+
 <p>External Attributes is an advanced feature. Please get in touch with our 
 <a href="&#109;&#097;&#105;&#108;&#116;&#111;:&#115;&#117;&#112;&#112;&#111;&#114;&#116;&#064;&#103;&#101;&#116;&#118;&#101;&#114;&#111;&#046;&#099;&#111;&#109;">support team via email</a> so we can show you it in action.</p>
 

--- a/_site/articles/why-a-specific-email-has-bounced.html
+++ b/_site/articles/why-a-specific-email-has-bounced.html
@@ -123,7 +123,7 @@
           
             
               <li>
-                <a class="article-link" href="/articles/automatically-unsubscribing-emails-that-have-bounced.html">Automtically unsubscribing emails that have bounced</a>
+                <a class="article-link" href="/articles/automatically-unsubscribing-emails-that-have-bounced.html">Automatically unsubscribing emails that have bounced</a>
               </li>
             
           

--- a/_site/feed.xml
+++ b/_site/feed.xml
@@ -5,8 +5,8 @@
     <description></description>
     <link>https://help.getvero.com/</link>
     <atom:link href="https://help.getvero.com/feed.xml" rel="self" type="application/rss+xml"/>
-    <pubDate>Thu, 22 Oct 2015 13:57:53 +1100</pubDate>
-    <lastBuildDate>Thu, 22 Oct 2015 13:57:53 +1100</lastBuildDate>
+    <pubDate>Fri, 23 Oct 2015 16:02:24 -0200</pubDate>
+    <lastBuildDate>Fri, 23 Oct 2015 16:02:24 -0200</lastBuildDate>
     <generator>Jekyll v2.5.3</generator>
     
   </channel>

--- a/_site/index.html
+++ b/_site/index.html
@@ -387,7 +387,7 @@
             
               
                 <li>
-                  <a class="article-link" href="/articles/automatically-unsubscribing-emails-that-have-bounced.html">Automtically unsubscribing emails that have bounced</a>
+                  <a class="article-link" href="/articles/automatically-unsubscribing-emails-that-have-bounced.html">Automatically unsubscribing emails that have bounced</a>
                 </li>
               
             


### PR DESCRIPTION
Fix typo: Change "Automtically" to "Automatically"

I commited the files in the `_site` directory (from `jekyll build`), but it's not clear in the README whether this should be done or not. This [commit](https://github.com/getvero/getvero.github.io/commit/c9365126b050fa1ab14daa81b4ffb77ad0dbb108) doesn't make it clear.

Therefore my PR also includes the compiled change from @chexton's [commit](https://github.com/getvero/getvero.github.io/commit/5cbf0cafebcbb9e9db9be948906f4e12d346d16c).
