### PR TITLE
Update title and desc for cancel page

### DIFF
--- a/_articles/cancel-your-vero-account.md
+++ b/_articles/cancel-your-vero-account.md
@@ -1,6 +1,6 @@
 ---
-title: Cancel your Vero account
-description: To cancel your Vero account, email support@getvero.com.
+title: Cancel your account
+description: To cancel your email marketing account, log in to your account and go to [Account > Billing](app.getvero.com/account/billing).
 categories:
 - billing
 layout: articles


### PR DESCRIPTION
removed the email address from the description and changed the copy to remove 'Vero' help prevent confusion with Vero True Social and reduce the chance of Search engine ranking for queries: 'Vero delete' and 'Vero cancel'.