### PR TITLE
add highlight js back

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,6 +14,11 @@
   <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/algoliasearch-helper-js/2.4.0/algoliasearch.helper.min.js"></script>
   <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/hogan.js/3.0.2/hogan.min.js"></script>
 
+  <!-- highlightjs - code highlighting -->
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/styles/default.min.css">
+  <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/highlight.min.js"></script>
+  <script>hljs.initHighlightingOnLoad();</script>
+
   <!-- Algolia -->
   <script src="https://cdn.jsdelivr.net/npm/instantsearch.js@2.5.1"></script>
   <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/instantsearch.js@2.5.1/dist/instantsearch.min.css">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,7 +15,7 @@
   <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/hogan.js/3.0.2/hogan.min.js"></script>
 
   <!-- highlightjs - code highlighting -->
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/styles/default.min.css">
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/styles/tomorrow-night-bright.min.css">
   <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/highlight.min.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>
 


### PR DESCRIPTION
Fixes: https://app.asana.com/0/512638426903826/651475893192710

Changes:

-Added highlight js and css back into the <head>

Review: 
@chexton It looks like highlight was removed during the algolia changes. I have added it back but let me know if that was intentional...