### PR TITLE
Fix typo 'reference'

### DIFF
--- a/_articles/using-arrays-in-your-email.md
+++ b/_articles/using-arrays-in-your-email.md
@@ -23,7 +23,7 @@ If you were to track the following:
   _veroq.push(['track',{ products: [ {name: 'Item 123', price: 10},  {name: 'Item ABC', price: 20} ] }]);  
   </script>
  
-You could referrnce the array in your email using [Liquid templating](https://github.com/Shopify/liquid/wiki/Liquid-for-Designers) as follows:
+You could reference the array in your email using [Liquid templating](https://github.com/Shopify/liquid/wiki/Liquid-for-Designers) as follows:
 
   {% raw %}
     {% for product in event.products %}


### PR DESCRIPTION
Fixed typo. 
'referrnce' = 'reference'