### PR TITLE
Updated webhooks to include message-id

### DIFF
--- a/_articles/setting-up-veros-webhooks.md
+++ b/_articles/setting-up-veros-webhooks.md
@@ -63,6 +63,7 @@ The follow list outlines each of the `type` values:
                 "trigger-event":"purchased item",
                 "permalink":"http://app.getvero.com/view/1/341d64944577ac1f70f560e37db54a25",
                 "variation":"Variation A"
+                "message_id": "20190730123456.1.1B72E094173067F0F@veromail.com"
             }
         }
 
@@ -83,6 +84,7 @@ The follow list outlines each of the `type` values:
                 "trigger-event":"purchased item",
                 "permalink":"http://app.getvero.com/view/1/341d64944577ac1f70f560e37db54a25",
                 "variation":"Variation A"
+                "message_id": "20190730123456.1.1B72E094173067F0F@veromail.com"
             }
         }
 
@@ -104,6 +106,7 @@ The follow list outlines each of the `type` values:
                 "trigger-event":"purchased item",
                 "permalink":"http://app.getvero.com/view/1/341d64944577ac1f70f560e37db54a25",
                 "variation":"Variation A"
+                "message_id": "20190730123456.1.1B72E094173067F0F@veromail.com"
             }
         }
 
@@ -125,6 +128,7 @@ The follow list outlines each of the `type` values:
                 "trigger-event":"purchased item",
                 "permalink":"http://app.getvero.com/view/1/341d64944577ac1f70f560e37db54a25",
                 "variation":"Variation A"
+                "message_id": "20190730123456.1.1B72E094173067F0F@veromail.com"
             }
         }
 
@@ -146,6 +150,7 @@ The follow list outlines each of the `type` values:
                 "trigger-event":"purchased item",
                 "permalink":"http://app.getvero.com/view/1/341d64944577ac1f70f560e37db54a25",
                 "variation":"Variation A"
+                "message_id": "20190730123456.1.1B72E094173067F0F@veromail.com"
             }
         }
 

--- a/_articles/setting-up-veros-webhooks.md
+++ b/_articles/setting-up-veros-webhooks.md
@@ -63,8 +63,8 @@ The follow list outlines each of the `type` values:
                 "trigger-event":"purchased item",
                 "permalink":"http://app.getvero.com/view/1/341d64944577ac1f70f560e37db54a25",
                 "variation":"Variation A"
-                "message_id": "20190730123456.1.1B72E094173067F0F@veromail.com"
-            }
+            },
+            "message_id": "20190730123456.1.1B72E094173067F0F@veromail.com"
         }
 
 **Delivered:**
@@ -84,8 +84,8 @@ The follow list outlines each of the `type` values:
                 "trigger-event":"purchased item",
                 "permalink":"http://app.getvero.com/view/1/341d64944577ac1f70f560e37db54a25",
                 "variation":"Variation A"
-                "message_id": "20190730123456.1.1B72E094173067F0F@veromail.com"
-            }
+            },
+            "message_id": "20190730123456.1.1B72E094173067F0F@veromail.com"
         }
 
 **Opened:**
@@ -106,8 +106,8 @@ The follow list outlines each of the `type` values:
                 "trigger-event":"purchased item",
                 "permalink":"http://app.getvero.com/view/1/341d64944577ac1f70f560e37db54a25",
                 "variation":"Variation A"
-                "message_id": "20190730123456.1.1B72E094173067F0F@veromail.com"
-            }
+            },
+            "message_id": "20190730123456.1.1B72E094173067F0F@veromail.com"
         }
 
 **Clicked:**
@@ -128,8 +128,8 @@ The follow list outlines each of the `type` values:
                 "trigger-event":"purchased item",
                 "permalink":"http://app.getvero.com/view/1/341d64944577ac1f70f560e37db54a25",
                 "variation":"Variation A"
-                "message_id": "20190730123456.1.1B72E094173067F0F@veromail.com"
-            }
+            },
+            "message_id": "20190730123456.1.1B72E094173067F0F@veromail.com"
         }
 
 **Bounced:**
@@ -150,8 +150,8 @@ The follow list outlines each of the `type` values:
                 "trigger-event":"purchased item",
                 "permalink":"http://app.getvero.com/view/1/341d64944577ac1f70f560e37db54a25",
                 "variation":"Variation A"
-                "message_id": "20190730123456.1.1B72E094173067F0F@veromail.com"
-            }
+            },
+            "message_id": "20190730123456.1.1B72E094173067F0F@veromail.com"
         }
 
 **Unsubscribed:**


### PR DESCRIPTION
Random example created: "message_id": "20190730123456.1.1B72E094173067F0F@veromail.com"