### PR TITLE
Update example AWS SNS IAM policy for mobile push

### DIFF
--- a/_articles/mobile-push-notifications-aws-sns-iam-access-policy.md
+++ b/_articles/mobile-push-notifications-aws-sns-iam-access-policy.md
@@ -45,6 +45,7 @@ We've included an example of a policy below. Below is an example of a policy des
             "Action": [
                 "sns:DeleteEndpoint",
                 "sns:CreatePlatformEndpoint",
+                "sns:GetEndpointAttributes",
                 "sns:ListPlatformApplications"
             ],
             "Resource": "*"


### PR DESCRIPTION
Fixes: #58
 
Changes done in this pull request:
- Added `sns:GetEndpointAttributes` permission to example AWS SNS IAM policy for mobile push

Person or team responsible to review these changes:
@probablyrory cc @chexton @jylamont
